### PR TITLE
Only add an entry for "true" isoforms.

### DIFF
--- a/Makefile-gafs
+++ b/Makefile-gafs
@@ -91,7 +91,7 @@ mirror/goa_chicken_isoform.gpi.gz:
 
 
 target/neo-goa_chicken_isoform.obo: mirror/goa_chicken_isoform.gpi.gz
-	gzip -dc mirror/goa_chicken_isoform.gpi.gz | ./gpi2obo.pl -s Ggal -n goa_chicken_isoform > $@.tmp && mv $@.tmp $@
+	gzip -dc mirror/goa_chicken_isoform.gpi.gz | ./gpi2obo.pl -s Ggal -n goa_chicken_isoform -I > $@.tmp && mv $@.tmp $@
 
 
 mirror/goa_chicken_rna.gpi.gz: 
@@ -123,7 +123,7 @@ mirror/goa_cow_isoform.gpi.gz:
 
 
 target/neo-goa_cow_isoform.obo: mirror/goa_cow_isoform.gpi.gz
-	gzip -dc mirror/goa_cow_isoform.gpi.gz | ./gpi2obo.pl -s Btau -n goa_cow_isoform > $@.tmp && mv $@.tmp $@
+	gzip -dc mirror/goa_cow_isoform.gpi.gz | ./gpi2obo.pl -s Btau -n goa_cow_isoform -I > $@.tmp && mv $@.tmp $@
 
 
 mirror/goa_cow_rna.gpi.gz: 
@@ -155,7 +155,7 @@ mirror/goa_dog_isoform.gpi.gz:
 
 
 target/neo-goa_dog_isoform.obo: mirror/goa_dog_isoform.gpi.gz
-	gzip -dc mirror/goa_dog_isoform.gpi.gz | ./gpi2obo.pl -s Cfam -n goa_dog_isoform > $@.tmp && mv $@.tmp $@
+	gzip -dc mirror/goa_dog_isoform.gpi.gz | ./gpi2obo.pl -s Cfam -n goa_dog_isoform -I > $@.tmp && mv $@.tmp $@
 
 
 mirror/goa_dog_rna.gpi.gz: 
@@ -187,7 +187,7 @@ mirror/goa_human_isoform.gpi.gz:
 
 
 target/neo-goa_human_isoform.obo: mirror/goa_human_isoform.gpi.gz
-	gzip -dc mirror/goa_human_isoform.gpi.gz | ./gpi2obo.pl -s Hsap -n goa_human_isoform > $@.tmp && mv $@.tmp $@
+	gzip -dc mirror/goa_human_isoform.gpi.gz | ./gpi2obo.pl -s Hsap -n goa_human_isoform -I > $@.tmp && mv $@.tmp $@
 
 
 mirror/goa_human_rna.gpi.gz: 
@@ -219,7 +219,7 @@ mirror/goa_pig_isoform.gpi.gz:
 
 
 target/neo-goa_pig_isoform.obo: mirror/goa_pig_isoform.gpi.gz
-	gzip -dc mirror/goa_pig_isoform.gpi.gz | ./gpi2obo.pl -s Sscr -n goa_pig_isoform > $@.tmp && mv $@.tmp $@
+	gzip -dc mirror/goa_pig_isoform.gpi.gz | ./gpi2obo.pl -s Sscr -n goa_pig_isoform -I > $@.tmp && mv $@.tmp $@
 
 
 mirror/goa_pig_rna.gpi.gz: 

--- a/build-neo-makefile.py
+++ b/build-neo-makefile.py
@@ -52,10 +52,14 @@ def build(datasets, args):
         toks = url.split("/")
         bn = "mirror/"+toks[-1]
         cmd = "./" + obj['type'] +"2obo.pl"
+
+        extra_args = ""
+        if 'isoform' in bn:
+            extra_args += " -I"
         target(bn,[],
                "wget "+url+" -O $@.tmp && mv $@.tmp $@")
         target("target/neo-"+db+".obo",[bn],
-               "gzip -dc "+bn+" | " + cmd + " -s "+ sp + " -n " + db + " > $@.tmp && mv $@.tmp $@")
+               "gzip -dc "+bn+" | " + cmd + " -s "+ sp + " -n " + db + extra_args + " > $@.tmp && mv $@.tmp $@")
             
 
 def target(tgt,deps,cmd):

--- a/gaf2obo.pl
+++ b/gaf2obo.pl
@@ -4,6 +4,7 @@ use strict;
 
 my $spn = 'generic';
 my $ontid;
+my $isoform_only = 0;
 
 while (@ARGV) {
     my $opt = shift @ARGV;
@@ -12,6 +13,9 @@ while (@ARGV) {
     }
     elsif ($opt eq '-n') {
         $ontid = shift @ARGV;
+    }
+    elsif ($opt eq '-I') {
+        $isoform_only = 1;
     }
 }
 if (!$ontid) {
@@ -37,6 +41,9 @@ while(<>) {
 
     $id = expand($id);
 
+    next if $isoform_only && $id !~ m@\-\d+$@;
+    
+    
 
     my $n = $vals[2];
     $n =~ tr/a-zA-Z0-9\-_//cd;

--- a/gpi2obo.pl
+++ b/gpi2obo.pl
@@ -4,6 +4,7 @@ use strict;
 
 my $spn = 'generic';
 my $ontid;
+my $isoform_only = 0;
 
 while (@ARGV) {
     my $opt = shift @ARGV;
@@ -12,6 +13,9 @@ while (@ARGV) {
     }
     elsif ($opt eq '-n') {
         $ontid = shift @ARGV;
+    }
+    elsif ($opt eq '-I') {
+        $isoform_only = 1;
     }
 }
 if (!$ontid) {
@@ -52,6 +56,8 @@ while(<>) {
 
     $id = expand($id);
 
+    next if $isoform_only && $id !~ m@\-\d+$@;
+    
     if (!$symbol) {
         # RNAs coming from UniProt or RNCA lack symbols
         $symbol = $local_id;


### PR DESCRIPTION
E.g. FANCA has a canonical/GCRP entry O15360 - we should use this
when isoform not known

The uniprot isoform file has both non-canonical TREMBLs like F5H8D5
as well as true/dash isoforms - keep only former.

Fixes #22

This should have been done when we did #20