### PR TITLE
Fix gene product URIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ foo:
 include Makefile-gafs
 
 neo.owl: neo.obo
-	owltools $< -o $@
+	owltools $< -o $@.tmp && ./bin/fix-obo-uris.pl $@.tmp > $@.tmp2 && mv $@.tmp2 $@
 
 Makefile-gafs: datasets.json
 	./build-neo-makefile.py -i $< > $@.tmp && mv $@.tmp $@

--- a/bin/fix-obo-uris.pl
+++ b/bin/fix-obo-uris.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/perl -np
+s@http://purl.obolibrary.org/obo/(dictyBase|ZFIN|FB|WB|SGD|PomBase|RGD|MGI|XenBase|UniProtKB|TAIR:\s+)_@"http://identifiers.org/".fix($1)."/"@eg;
+
+sub fix {
+    $s = lc($_[0]);
+    $s =~ s@^fb$@flybase@;
+    $s =~ s@^wb$@wormbase@;
+    $s =~ s@^uniprotkb$@uniprot@;
+    $s =~ s@^tair:@tair.@;
+    return $s;
+}
+

--- a/build-neo-makefile.py
+++ b/build-neo-makefile.py
@@ -29,7 +29,8 @@ def build(datasets, args):
     for d in datasets:
         dn = d['dataset']
         t = d['type']
-        if t == 'gpi':
+        # temporary: see https://github.com/geneontology/go-site/issues/595
+        if t == 'gpi' and dn != 'wb':
             smap[dn] = d
         elif t == 'gaf':
             if dn not in smap:


### PR DESCRIPTION
URIs now consistent with rdf_uri_prefix in dbxrefs yaml

CURIEs go in oio:id property

Note this is a temp fix for #17