### PR TITLE
Revert build-neo-makefile.py

### DIFF
--- a/build-neo-makefile.py
+++ b/build-neo-makefile.py
@@ -29,8 +29,7 @@ def build(datasets, args):
     for d in datasets:
         dn = d['dataset']
         t = d['type']
-        # temporary: see https://github.com/geneontology/go-site/issues/595
-        if t == 'gpi' and dn != 'wb':
+        if t == 'gpi':
             smap[dn] = d
         elif t == 'gaf':
             if dn not in smap:


### PR DESCRIPTION
Revert temp workaround for https://github.com/geneontology/go-site/issues/595 , to directly address https://github.com/geneontology/neo/issues/38