### PR TITLE
Update Makefile with new location for sars-cov-2 data (kg)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ foo:
 
 # BUG: temporary hardcode until https://github.com/geneontology/go-site/issues/1431 is resolved and stable GPI URL is established
 mirror/goa_sars-cov-2.gpi.gz:
-	wget --no-check-certificate ftp://ftp.ebi.ac.uk/pub/contrib/goa/uniprot_sars-cov-2.gpi -O mirror/goa_sars-cov-2.gpi && gzip mirror/goa_sars-cov-2.gpi
+	wget --no-check-certificate https://raw.githubusercontent.com/Knowledge-Graph-Hub/kg-covid-19/master/curated/ORFs/uniprot_sars-cov-2.gpi -O mirror/goa_sars-cov-2.gpi && gzip mirror/goa_sars-cov-2.gpi
 target/neo-goa_sars-cov-2.obo: mirror/goa_sars-cov-2.gpi.gz
 	gzip -dc $< | ./gpi2obo.pl -s Scov2 -n sars-cov-2 > $@.tmp && mv $@.tmp $@
 


### PR DESCRIPTION
@cmungall Is this what you are wanting? Is there (ideally?) a better location from the KG-HUB distribution?

Noting:
https://github.com/geneontology/go-site/issues/1431
https://github.com/geneontology/neo/issues/60