### PR TITLE
Ensure AGI_LocusCode IDs are compacted in oio:id values.

### DIFF
--- a/bin/fix-obo-uris.pl
+++ b/bin/fix-obo-uris.pl
@@ -8,6 +8,9 @@ s@http://purl.obolibrary.org/obo/GR_protein_@http://identifiers.org/uniprot/@g;
 s@http://purl.obolibrary.org/obo/dictyBase#_@http://identifiers.org/dictybase.gene/@g;
 s@http://purl.obolibrary.org/obo/ComplexPortal_@https://www.ebi.ac.uk/complexportal/complex/@g;
 s@http://purl.obolibrary.org/obo/RNAcentral#_@http://rnacentral.org/rna/@g;
+# This substitution targets AGI_LocusCode IDs within literal values, forcing the oboInOwl:id field to be compacted.
+# See https://github.com/geneontology/neo/issues/106
+s@>http://purl.obolibrary.org/obo/AGI_LocusCode_@>AGI_LocusCode:@g;
 # This script edits an XML file; thus the ampersand must be escaped
 s@http://purl.obolibrary.org/obo/AGI_LocusCode_@http://arabidopsis.org/servlets/TairObject?type=locus&amp;name=@g;
 # The optional hash in the match deals with some odd OWLAPI OBO parser behavior


### PR DESCRIPTION
For #106. This is kind of a hack, but that fits the theme of `fix-obo-uris.pl`. `AGI_LocusCode` IDs don't seem to be given the `oboInOwl:id` compacted value by the OWL API parser, due to the underscore within the prefix.

Alternatively we could use a different prefix for these identifiers, but I'm not sure of the origin of this particular prefix and who else uses it.

I believe that if the compacted form is in the ontology as an `oboInOwl:id` value, things should look correct in the Solr load.