### PR TITLE
Use new support for prefixes in OBO format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ include Makefile-gafs
 # The default owltools expansion makes this an OBO PURLs
 # We then "reverse" this with some hacky regexes...
 neo.owl: neo.obo
-	owltools $< -o $@.tmp && ./bin/fix-obo-uris.pl $@.tmp > $@.tmp2 && mv $@.tmp2 $@
+	robot convert -i $< -o $@.tmp -f owl && mv $@.tmp $@
 
 Makefile-gafs: datasets.json
 	./build-neo-makefile.py -i $< > $@.tmp && mv $@.tmp $@
@@ -110,7 +110,5 @@ rnacentral.gpi: rnacentral.gpi.gz
 target/neo-rnac.obo: rnacentral.gpi.gz
 	gzip -dc $< | ./rnacgpi2obo.pl > $@.tmp && mv $@.tmp $@
 
-target/xneo-%.owl: target/neo-%.obo
-	owltools $< -o $@.tmp && mv $@.tmp $@
-target/neo-%.owl: target/xneo-%.owl
-	./bin/fix-obo-uris.pl $< >  $@.tmp && mv $@.tmp $@
+target/neo-%.owl: target/neo-%.obo
+	robot convert -i $< -o $@.tmp -f owl && mv $@.tmp $@

--- a/gaf2obo.pl
+++ b/gaf2obo.pl
@@ -5,6 +5,8 @@ use strict;
 my $spn = 'generic';
 my $ontid;
 my $isoform_only = 0;
+open my $fh, '<', 'prefixes.obo.txt' or die "error opening prefixes.obo.txt: $!";
+my $prefixes = do { local $/; <$fh> };
 
 while (@ARGV) {
     my $opt = shift @ARGV;
@@ -24,6 +26,8 @@ if (!$ontid) {
 
 my $is_rat = $spn eq 'Rnor';
 
+print "format-version: 1.2\n";
+print $prefixes;
 print "ontology: go/noctua/$ontid\n";
 print "\n";
 

--- a/gpi2obo.pl
+++ b/gpi2obo.pl
@@ -6,6 +6,8 @@ my $spn = 'generic';
 my $fill_p = 0; # fill unknown species name with taxon id
 my $ontid;
 my $isoform_only = 0;
+open my $fh, '<', 'prefixes.obo.txt' or die "error opening prefixes.obo.txt: $!";
+my $prefixes = do { local $/; <$fh> };
 
 while (@ARGV) {
     my $opt = shift @ARGV;
@@ -26,6 +28,8 @@ if (!$ontid) {
     $ontid = $spn;
 }
 
+print "format-version: 1.2\n";
+print $prefixes;
 print "ontology: go/noctua/$ontid\n";
 print "\n";
 

--- a/prefixes.obo.txt
+++ b/prefixes.obo.txt
@@ -1,4 +1,4 @@
-idspace: AGI_LocusCode http://arabidopsis.org/servlets/TairObject?type=locus&amp;name=
+idspace: AGI_LocusCode http://arabidopsis.org/servlets/TairObject?type=locus&name=
 idspace: ComplexPortal https://www.ebi.ac.uk/complexportal/complex/
 idspace: dictyBase http://identifiers.org/dictybase.gene/
 idspace: FB http://identifiers.org/flybase/

--- a/prefixes.obo.txt
+++ b/prefixes.obo.txt
@@ -1,0 +1,15 @@
+idspace: AGI_LocusCode http://arabidopsis.org/servlets/TairObject?type=locus&amp;name=
+idspace: ComplexPortal https://www.ebi.ac.uk/complexportal/complex/
+idspace: dictyBase http://identifiers.org/dictybase.gene/
+idspace: FB http://identifiers.org/flybase/
+idspace: GR_protein http://identifiers.org/uniprot/
+idspace: MGI http://identifiers.org/mgi/
+idspace: PomBase http://identifiers.org/pombase/
+idspace: RGD http://identifiers.org/rgd/
+idspace: RNAcentral http://rnacentral.org/rna/
+idspace: SGD http://identifiers.org/sgd/
+idspace: TAIR_locus http://identifiers.org/tair.locus/
+idspace: UniProtKB http://identifiers.org/uniprot/
+idspace: WB http://identifiers.org/wormbase/
+idspace: Xenbase http://identifiers.org/xenbase/
+idspace: ZFIN http://identifiers.org/zfin/

--- a/rnacgpi2obo.pl
+++ b/rnacgpi2obo.pl
@@ -18,8 +18,12 @@ our @taxa = qw(
 );
 
 my %tm = map {($_=>1)} @taxa;
-    
 
+open my $fh, '<', 'prefixes.obo.txt' or die "error opening prefixes.obo.txt: $!";
+my $prefixes = do { local $/; <$fh> };
+
+print "format-version: 1.2\n";
+print $prefixes;
 print "ontology: go/noctua/rnac\n";
 print "\n";
 


### PR DESCRIPTION
The latest ROBOT includes new OWL API support to make use of prefix definitions in OBO format. This will allow us to get rid of the perl regex hack. This should be a fix for https://github.com/geneontology/noctua/issues/902. Also relates to #84 and #17.

These changes haven't been tested on a full build yet—may need to tweak prefix definitions. Also, the latest ROBOT is required for this to work.